### PR TITLE
Implement simple hand history logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ Run the simulation:
 ```
 python main.py
 ```
+
+Hand histories from each game can be saved with:
+```
+from engine import PokerEngine
+eng = PokerEngine()
+eng.new_hand()
+... # play some actions
+eng.save_histories("hand_history.json")
+```

--- a/test_engine.py
+++ b/test_engine.py
@@ -1,0 +1,47 @@
+import unittest
+from engine import PokerEngine
+
+
+class TestPokerEngine(unittest.TestCase):
+    def test_hand_progression(self):
+        eng = PokerEngine(num_players=3, starting_stack=100, sb_amt=1, bb_amt=2)
+        eng.new_hand()
+
+        # pre-flop: all players call or check
+        eng.player_action("call")  # seat 0
+        eng.player_action("call")  # seat 1
+        eng.player_action("check")  # seat 2 (big blind)
+        self.assertEqual(eng.stage, "flop")
+        self.assertEqual(eng.pot, 6)
+
+        # flop: everyone checks
+        eng.player_action("check")  # seat left of button
+        eng.player_action("check")
+        eng.player_action("check")
+        self.assertEqual(eng.stage, "turn")
+
+        # turn: everyone checks
+        eng.player_action("check")
+        eng.player_action("check")
+        eng.player_action("check")
+        self.assertEqual(eng.stage, "river")
+
+        # river: everyone checks -> hand complete
+        eng.player_action("check")
+        eng.player_action("check")
+        eng.player_action("check")
+        self.assertEqual(eng.stage, "complete")
+        self.assertEqual(sum(eng.stacks), 300)
+
+        # history should contain one hand with recorded actions
+        self.assertEqual(len(eng.hand_histories), 1)
+        history = eng.hand_histories[0]
+        self.assertIn("winners", history)
+        self.assertIn("actions", history)
+
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+


### PR DESCRIPTION
## Summary
- track actions and results for each poker hand
- add `save_histories` to dump histories in JSON
- document hand history usage in README
- test that a history entry is created

## Testing
- `python -m py_compile engine.py main.py test_engine.py`
- `python -m unittest -v` *(fails: ModuleNotFoundError: No module named 'pokerkit')*