### PR TITLE
Enhance table UI and add hand history log

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,18 @@
 import sys
 from PyQt5.QtWidgets import (
-    QApplication, QMainWindow, QWidget,
-    QVBoxLayout, QGridLayout, QHBoxLayout,
-    QPushButton, QLabel, QFrame, QComboBox,
-    QSpinBox, QSlider
+    QApplication,
+    QMainWindow,
+    QWidget,
+    QVBoxLayout,
+    QGridLayout,
+    QHBoxLayout,
+    QPushButton,
+    QLabel,
+    QFrame,
+    QComboBox,
+    QSpinBox,
+    QSlider,
+    QPlainTextEdit,
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QPainter, QColor, QFont
@@ -125,9 +134,12 @@ class MainWindow(QMainWindow):
         central = QWidget()
         self.setCentralWidget(central)
         vbox = QVBoxLayout(central)
-        grid = QGridLayout()
+
+        table_frame = QFrame()
+        table_frame.setStyleSheet("background-color: darkgreen; border-radius: 15px;")
+        grid = QGridLayout(table_frame)
         grid.setSpacing(20)
-        vbox.addLayout(grid)
+        vbox.addWidget(table_frame)
 
         # create seats around the table
         self.seats = []
@@ -194,6 +206,13 @@ class MainWindow(QMainWindow):
         self.button.clicked.connect(self.on_button)
         vbox.addWidget(self.button, alignment=Qt.AlignCenter)
 
+        self.history_box = QPlainTextEdit()
+        self.history_box.setReadOnly(True)
+        self.history_box.setFixedHeight(150)
+        vbox.addWidget(self.history_box)
+
+        self.last_action_index = 0
+
         self.player_seat = 0
 
     def join_game(self):
@@ -241,6 +260,33 @@ class MainWindow(QMainWindow):
             seat.setBet(self.engine.contributions[i])
         self.community.setCards(self.engine.community)
         self.pot_label.setText(f"Pot: {self.engine.pot}")
+        self.update_history()
+
+    def update_history(self):
+        hist = getattr(self.engine, "_current_history", None)
+        if not hist:
+            return
+        actions = hist.get("actions", [])
+        for action in actions[self.last_action_index:]:
+            player = action.get("player")
+            act = action.get("action")
+            amt = action.get("amount", 0)
+            if act == "blind":
+                line = f"Seat {player} posted blind {amt}"
+            elif act == "bet":
+                line = f"Seat {player} bet {amt}"
+            elif act == "raise":
+                line = f"Seat {player} raised {amt}"
+            elif act == "call":
+                line = f"Seat {player} called {amt}"
+            elif act == "check":
+                line = f"Seat {player} checked"
+            elif act == "fold":
+                line = f"Seat {player} folded"
+            else:
+                line = f"Seat {player} {act} {amt}"
+            self.history_box.appendPlainText(line)
+        self.last_action_index = len(actions)
 
     def on_button(self):
         if self.stage == 0:
@@ -253,12 +299,22 @@ class MainWindow(QMainWindow):
             self.community.setCards([])
             self.pot_label.setText(f"Pot: {self.engine.pot}")
             self.stage = 1
+            self.history_box.clear()
+            self.last_action_index = 0
             self.bot_action()
             self.update_display()
         elif self.stage == 1 and self.engine.stage == "complete":
             winners = self.engine.hand_histories[-1]["winners"] if self.engine.hand_histories else []
+            win_set = set()
+            for rec in winners:
+                win_set.update(rec.get("winners", []))
             for i, seat in enumerate(self.seats):
-                seat.highlight(i in winners)
+                seat.highlight(i in win_set)
+            if win_set:
+                winner_seats = ", ".join(str(s) for s in sorted(win_set))
+                self.history_box.appendPlainText(
+                    f"Hand complete. Winners: {winner_seats}"
+                )
             self.button.setText("Deal")
             self.stage = 0
 


### PR DESCRIPTION
## Summary
- color the main table frame dark green to look like a poker table
- add a chat-style text box that records actions during each hand
- clear and update the history box as actions occur and when a hand finishes
- highlight winning seats using the new recorded set

## Testing
- `python -m unittest -v`
- `pip install flake8` *(failed: Could not find a version that satisfies the requirement flake8)*