### PR TITLE
Hide bot cards until showdown

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,8 @@ from PyQt5.QtWidgets import (
     QSpinBox, QSlider
 )
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QPainter, QColor, QFont
+from PyQt5.QtGui import QPainter, QColor, QFont, QPixmap
+import os
 from engine import PokerEngine
 
 
@@ -14,10 +15,14 @@ class CardWidget(QFrame):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.card = None
+        self.face_down = False
+        back_path = os.path.join(os.path.dirname(__file__), "assets", "unnamed.png")
+        self.back_image = QPixmap(back_path)
         self.setFixedSize(60, 90)
 
-    def setCard(self, card):
+    def setCard(self, card, face_down=False):
         self.card = card
+        self.face_down = face_down
         self.update()
 
     def paintEvent(self, event):
@@ -26,7 +31,9 @@ class CardWidget(QFrame):
         painter.fillRect(rect, QColor('white'))
         painter.setPen(QColor('black'))
         painter.drawRect(rect)
-        if self.card:
+        if self.face_down:
+            painter.drawPixmap(rect, self.back_image)
+        elif self.card:
             rank_map = {2: '2', 3: '3', 4: '4', 5: '5', 6: '6',
                         7: '7', 8: '8', 9: '9', 10: '10',
                         11: 'J', 12: 'Q', 13: 'K', 14: 'A'}
@@ -79,13 +86,13 @@ class SeatWidget(QWidget):
     def setBet(self, amount):
         self.bet_label.setText(f"Bet: {amount}")
 
-    def setCards(self, cards):
+    def setCards(self, cards, face_down=False):
         if cards:
-            self.card1.setCard(cards[0])
-            self.card2.setCard(cards[1])
+            self.card1.setCard(cards[0], face_down)
+            self.card2.setCard(cards[1], face_down)
         else:
-            self.card1.setCard(None)
-            self.card2.setCard(None)
+            self.card1.setCard(None, face_down)
+            self.card2.setCard(None, face_down)
 
     def highlight(self, state):
         self._winner = state
@@ -299,7 +306,7 @@ class MainWindow(QMainWindow):
                 seat.highlight(False)
                 seat.setStack(self.engine.stacks[i])
                 seat.setBet(self.engine.contributions[i])
-                seat.setCards(holes.get(i))
+                seat.setCards(holes.get(i), face_down=not seat.is_player)
                 seat.set_turn(i == self.engine.turn)
             self.community.setCards([])
             self.pot_label.setText(f"Pot: {self.engine.pot}")
@@ -309,6 +316,7 @@ class MainWindow(QMainWindow):
         elif self.stage == 1 and self.engine.stage == "complete":
             winners = self.engine.hand_histories[-1]["winners"] if self.engine.hand_histories else []
             for i, seat in enumerate(self.seats):
+                seat.setCards(self.engine.hole_cards.get(i))
                 seat.highlight(i in winners)
                 seat.set_turn(False)
             self.button.setText("Deal")


### PR DESCRIPTION
## Summary
- prevent bots' hole cards from being visible before showdown
- display the back of a card image for bots
- reveal all hole cards once the hand is complete

## Testing
- `python -m unittest -v`
- `flake8` *(fails: command not found)*