### PR TITLE
Switch to playing_card_back icon

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,9 @@ class CardWidget(QFrame):
         super().__init__(parent)
         self.card = None
         self.face_down = False
-        back_path = os.path.join(os.path.dirname(__file__), "assets", "unnamed.png")
+        back_path = os.path.join(
+            os.path.dirname(__file__), "assets", "playing_card_back.png"
+        )
         self.back_image = QPixmap(back_path)
         self.setFixedSize(60, 90)
 


### PR DESCRIPTION
## Summary
- use the playing_card_back.png asset for facedown cards

## Testing
- `python -m unittest -v`