### PR TITLE
Add win amounts to history

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -193,6 +193,14 @@ class PokerEngine:
         if sum(self.active) == 1:
             winner = next(i for i, a in enumerate(self.active) if a)
             self.stacks[winner] += self.pot
+            if self._current_history is not None:
+                winners_record = [{"pot": self.pot, "winners": [winner], "share": self.pot}]
+                self._current_history["winners"] = winners_record
+                self._current_history["final_stacks"] = self.stacks.copy()
+                self._current_history["community"] = self.community.copy()
+                self.hand_histories.append(self._current_history)
+                self._current_history = None
+            self.pot = 0
             self.stage = "complete"
             return
 
@@ -331,7 +339,11 @@ class PokerEngine:
             share = pot["amount"] // len(winners)
             for w in winners:
                 self.stacks[w] += share
-            winners_record.append({"pot": pot["amount"], "winners": winners})
+            winners_record.append({
+                "pot": pot["amount"],
+                "winners": winners,
+                "share": share,
+            })
 
         if self._current_history is not None:
             self._current_history["winners"] = winners_record

--- a/main.py
+++ b/main.py
@@ -419,9 +419,12 @@ class MainWindow(QMainWindow):
                 if self.engine.hand_histories
                 else []
             )
-            win_set = set()
+            win_map = {}
             for rec in winners:
-                win_set.update(rec.get("winners", []))
+                share = rec.get("share", rec.get("pot", 0) // max(1, len(rec.get("winners", []))))
+                for w in rec.get("winners", []):
+                    win_map[w] = win_map.get(w, 0) + share
+            win_set = set(win_map.keys())
             for i, seat in enumerate(self.seats):
                 seat.setCards(self.engine.hole_cards.get(i))
                 seat.highlight(i in win_set)
@@ -429,10 +432,11 @@ class MainWindow(QMainWindow):
                 seat.set_turn(False)
 
             if win_set:
-                winner_seats = ", ".join(str(s) for s in sorted(win_set))
-                self.history_box.appendPlainText(
-                    f"Hand complete. Winners: {winner_seats}"
-                )
+                for seat_num in sorted(win_map):
+                    amt = win_map[seat_num]
+                    self.history_box.appendPlainText(
+                        f"Hand complete. Seat {seat_num} won {amt}"
+                    )
             self.button.setText("Deal")
             self.stage = 0
 


### PR DESCRIPTION
## Summary
- record each winning player's share of the pot
- save history for fold-to-win scenarios
- show pot winnings in the GUI chat box

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python test_engine.py`