### PR TITLE
Fix partial raise logic in PokerEngine

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -173,16 +173,27 @@ class PokerEngine:
                 raise ValueError("Raise amount must be positive")
             to_call = self.current_bet - self.contributions[player]
             raise_total = to_call + amount
-            actual = min(raise_total, self.stacks[player])
-            self.stacks[player] -= actual
-            self.contributions[player] += actual
-            self.total_contrib[player] += actual
-            self.pot += actual
-            self.current_bet = self.contributions[player]
-            self.last_raiser = player
-            event_amount = actual
-            if self.stacks[player] == 0:
-                self.all_in[player] = True
+            if raise_total > self.stacks[player]:
+                # Not enough chips for a full raise -> treat as all-in call
+                actual = self.stacks[player]
+                self.stacks[player] -= actual
+                self.contributions[player] += actual
+                self.total_contrib[player] += actual
+                self.pot += actual
+                event_amount = actual
+                if self.stacks[player] == 0:
+                    self.all_in[player] = True
+            else:
+                actual = raise_total
+                self.stacks[player] -= actual
+                self.contributions[player] += actual
+                self.total_contrib[player] += actual
+                self.pot += actual
+                self.current_bet = self.contributions[player]
+                self.last_raiser = player
+                event_amount = actual
+                if self.stacks[player] == 0:
+                    self.all_in[player] = True
         else:
             raise ValueError(f"Unknown action: {action}")
 

--- a/test_engine.py
+++ b/test_engine.py
@@ -78,6 +78,18 @@ class TestPokerEngine(unittest.TestCase):
 
         os.remove(path)
 
+    def test_partial_raise_does_not_lower_current_bet(self):
+        """Short all-in raise should not change the current bet."""
+        eng = PokerEngine(num_players=3, starting_stack=50, sb_amt=1, bb_amt=2)
+        eng.new_hand()
+
+        eng.player_action("raise", 100)
+        self.assertEqual(eng.current_bet, eng.bb_amt)
+        self.assertEqual(eng.turn, eng.sb)
+
+        eng.player_action("call")
+        self.assertEqual(eng.stage, "flop")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- prevent `current_bet` from dropping when a short stack attempts an oversized raise
- test that a partial raise keeps the current bet unchanged

## Testing
- `python -m unittest -v`