### PR TITLE
Add equity/strength stats option

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -7,9 +7,9 @@ Poker game engine for Texas Hold'em using pokerkit.
 import json
 import random
 
-from pokerkit.hands import StandardHighHand
-from pokerkit.utilities import Card as PKCard
-from pokerkit.utilities import Deck
+from pokerkit.pokerkit.hands import StandardHighHand
+from pokerkit.pokerkit.utilities import Card as PKCard
+from pokerkit.pokerkit.utilities import Deck
 
 
 class PokerEngine:
@@ -225,7 +225,6 @@ class PokerEngine:
             self.stage = "complete"
             return
 
-        start = self.turn
         found = False
         for _ in range(self.num_players):
             self.turn = (self.turn + 1) % self.num_players

--- a/pokerkit/__init__.py
+++ b/pokerkit/__init__.py
@@ -1,0 +1,11 @@
+"""Expose the actual PokerKit package bundled as a submodule."""
+
+from importlib import import_module
+from pathlib import Path
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
+__path__.append(str(Path(__file__).resolve().parent / "pokerkit"))
+
+module = import_module(".pokerkit", __name__)
+globals().update(module.__dict__)


### PR DESCRIPTION
## Summary
- compute equity vs random opponents and hand strength via new helpers
- show equity and hand strength in UI with toggle
- fix linter issue in engine
- expose PokerKit package at repo root so imports work

## Testing
- `ruff check .`
- `python -m unittest test_engine.py`
