### PR TITLE
Add winning hand info to hand history

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -215,7 +215,14 @@ class PokerEngine:
             winner = next(i for i, a in enumerate(self.active) if a)
             self.stacks[winner] += self.pot
             if self._current_history is not None:
-                winners_record = [{"pot": self.pot, "winners": [winner], "share": self.pot}]
+                winners_record = [
+                    {
+                        "pot": self.pot,
+                        "winners": [winner],
+                        "share": self.pot,
+                        "hand": None,
+                    }
+                ]
                 self._current_history["winners"] = winners_record
                 self._current_history["final_stacks"] = self.stacks.copy()
                 self._current_history["community"] = self.community.copy()
@@ -365,11 +372,14 @@ class PokerEngine:
             share = pot["amount"] // len(winners)
             for w in winners:
                 self.stacks[w] += share
-            winners_record.append({
-                "pot": pot["amount"],
-                "winners": winners,
-                "share": share,
-            })
+            winners_record.append(
+                {
+                    "pot": pot["amount"],
+                    "winners": winners,
+                    "share": share,
+                    "hand": best_hand.entry.label.value if best_hand else None,
+                }
+            )
 
         if self._current_history is not None:
             self._current_history["winners"] = winners_record

--- a/main.py
+++ b/main.py
@@ -320,10 +320,16 @@ class MainWindow(QMainWindow):
             else []
         )
         win_map = {}
+        hand_map = {}
         for rec in winners:
-            share = rec.get("share", rec.get("pot", 0) // max(1, len(rec.get("winners", []))))
+            share = rec.get(
+                "share", rec.get("pot", 0) // max(1, len(rec.get("winners", [])))
+            )
+            label = rec.get("hand")
             for w in rec.get("winners", []):
                 win_map[w] = win_map.get(w, 0) + share
+                if label:
+                    hand_map[w] = label
         win_set = set(win_map.keys())
         for i, seat in enumerate(self.seats):
             seat.setCards(self.engine.hole_cards.get(i))
@@ -334,9 +340,11 @@ class MainWindow(QMainWindow):
         if win_set and not self.winners_displayed:
             for seat_num in sorted(win_map):
                 amt = win_map[seat_num]
-                self.history_box.appendPlainText(
-                    f"Hand complete. Seat {seat_num} won {amt}"
-                )
+                label = hand_map.get(seat_num)
+                line = f"Hand complete. Seat {seat_num} won {amt}"
+                if label:
+                    line += f" with {label}"
+                self.history_box.appendPlainText(line)
             self.winners_displayed = True
         self.button.setText("Deal")
         self.stage = 0
@@ -513,18 +521,24 @@ class MainWindow(QMainWindow):
             and hist.get("winners")
         ):
             win_map = {}
+            hand_map = {}
             for rec in hist["winners"]:
                 share = rec.get(
                     "share",
                     rec.get("pot", 0) // max(1, len(rec.get("winners", []))),
                 )
+                label = rec.get("hand")
                 for w in rec.get("winners", []):
                     win_map[w] = win_map.get(w, 0) + share
+                    if label:
+                        hand_map[w] = label
             for seat_num in sorted(win_map):
                 amt = win_map[seat_num]
-                self.history_box.appendPlainText(
-                    f"Hand complete. Seat {seat_num} won {amt}"
-                )
+                label = hand_map.get(seat_num)
+                line = f"Hand complete. Seat {seat_num} won {amt}"
+                if label:
+                    line += f" with {label}"
+                self.history_box.appendPlainText(line)
             self.winners_displayed = True
 
     def on_button(self):

--- a/test_engine.py
+++ b/test_engine.py
@@ -40,6 +40,8 @@ class TestPokerEngine(unittest.TestCase):
         history = eng.hand_histories[0]
         self.assertIn("winners", history)
         self.assertIsInstance(history["winners"], list)
+        for rec in history["winners"]:
+            self.assertIn("hand", rec)
         self.assertIn("actions", history)
 
     def test_fold_to_single_player(self):
@@ -50,6 +52,8 @@ class TestPokerEngine(unittest.TestCase):
         eng.player_action("fold")
         self.assertEqual(eng.stage, "complete")
         self.assertEqual(eng.stacks[eng.bb], 101)
+        history = eng.hand_histories[0]
+        self.assertIsNone(history["winners"][0]["hand"])
 
     def test_engine_from_config(self):
         pass
@@ -63,6 +67,10 @@ class TestPokerEngine(unittest.TestCase):
         eng.player_action("call")  # seat 1 calls remaining 3
         self.assertEqual(eng.stage, "complete")
         self.assertEqual(sum(eng.stacks), 10)
+        # ensure winning hand label recorded
+        history = eng.hand_histories[0]
+        for rec in history["winners"]:
+            self.assertIsNotNone(rec["hand"]) 
 
         path = "temp_config.json"
         with open(path, "w", encoding="utf-8") as fh:


### PR DESCRIPTION
## Summary
- include winning hand labels when recording winners
- show winning hand info in the GUI history box
- test for the new `hand` field in histories

## Testing
- `python -m unittest -v`
- `black --check engine.py main.py test_engine.py` *(fails: would reformat test_engine.py, main.py)*