### PR TITLE
Fix texas_solver future import error

### DIFF
--- a/texas_solver.py
+++ b/texas_solver.py
@@ -5,87 +5,10 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Iterable
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
+from typing import Iterable, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type checking
     from engine import PokerEngine
-from typing import Any, Dict
-
-
-def simple_parameter_file(board: str, ranges: str, out_dir: str) -> str:
-    """Create a basic parameter file for console_solver.exe."""
-    os.makedirs(out_dir, exist_ok=True)
-    params = {
-        "board": board,
-        "ranges": ranges,
-        "output": os.path.join(out_dir, "solver_output.json"),
-    }
-    param_path = os.path.join(out_dir, "params.json")
-    with open(param_path, "w", encoding="utf-8") as fh:
-        json.dump(params, fh)
-    return param_path
-
-
-def run_console_solver(param_file: str, solver_dir: str = "TexasSolver-v0.2.0-Windows") -> subprocess.CompletedProcess:
-    """Invoke console_solver.exe with the supplied parameter file."""
-    exe = os.path.join(solver_dir, "console_solver.exe")
-    return subprocess.run([exe, param_file], capture_output=True, text=True)
-
-
-def parse_solver_output(output_json: str) -> Dict[str, Any]:
-    """Return the parsed JSON output from the solver."""
-    with open(output_json, encoding="utf-8") as fh:
-        return json.load(fh)
-import json
-import os
-import subprocess
-from typing import Any
-
-from engine import PokerEngine
-
-
-def simple_parameter_file(engine: PokerEngine, seat: int, path: str) -> str:
-    """Write a basic parameter JSON file for ``console_solver.exe``.
-
-    The JSON contains hole cards, board cards, stack sizes, and current bets.
-    """
-    data: dict[str, Any] = {
-        "hero_seat": seat,
-        "board": [engine._tuple_to_str(c) for c in engine.community],
-        "holes": {
-            str(i): [engine._tuple_to_str(c) for c in cards]
-            for i, cards in engine.hole_cards.items()
-        },
-        "stacks": engine.stacks,
-        "contributions": engine.contributions,
-        "current_bet": engine.current_bet,
-        "pot": engine.pot,
-    }
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w", encoding="utf-8") as fh:
-        json.dump(data, fh, indent=2)
-    return path
-
-
-def run_console_solver(param_path: str) -> str:
-    """Invoke ``console_solver.exe`` using Wine and return its output."""
-    exe = os.path.join(
-        os.path.dirname(__file__), "TexasSolver-v0.2.0-Windows", "console_solver.exe"
-    )
-    cmd = ["wine", exe, param_path]
-    try:
-        return subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT)
-    except Exception as exc:  # pragma: no cover - external process may fail
-        return str(exc)
-"""Utility functions for running TexasSolver from Python."""
-
-from __future__ import annotations
-
-import json
-import subprocess
-import sys
-from pathlib import Path
-from typing import Iterable
 
 DEFAULT_EXE_DIR = Path("TexasSolver-v0.2.0-Windows")
 
@@ -104,36 +27,6 @@ def run_console_solver(
 
     if use_wine is None:
         use_wine = sys.platform != "win32"
-    """Run ``console_solver.exe`` with the given parameter file."""
-    """Run ``console_solver.exe`` with the given parameter file.
-
-    Parameters
-    ----------
-    param_file : Path or str
-        Path to the solver parameter file.
-    exe_dir : Path or str, optional
-        Directory containing ``console_solver.exe``. Defaults to
-        ``TexasSolver-v0.2.0-Windows`` in the repository root.
-    use_wine : bool, optional
-        Force using ``wine`` to execute the solver. By default, this is
-        automatically chosen based on the current platform.
-    timeout : int, optional
-        Timeout in seconds passed to :func:`subprocess.run`.
-
-    Returns
-    -------
-    str
-        The raw text output from the solver.
-    """
-
-    param_path = Path(param_file)
-    exe_directory = Path(exe_dir)
-    exe = exe_directory / "console_solver.exe"
-
-    if use_wine is None:
-        use_wine = sys.platform != "win32"
-
-    cmd = [str(exe), str(param_path)]
     if use_wine:
         cmd.insert(0, "wine")
 
@@ -156,7 +49,6 @@ def simple_parameter_file(
     range_ip: str,
     output_path: Path | str,
 ) -> Path:
-    """Create a minimal parameter file for a heads-up spot."""
     """Create a minimal parameter file for a heads-up flop spot."""
 
     board_str = ",".join(board) if board else ""
@@ -194,26 +86,10 @@ def engine_parameter_file(engine: "PokerEngine", seat: int, path: str) -> str:
     with open(path, "w", encoding="utf-8") as fh:
         json.dump(data, fh, indent=2)
     return path
+
+
 def parse_solver_output(output: str, hero_hand: str) -> tuple[str, int]:
     """Return the highest frequency action from solver output."""
-def parse_solver_output(output: str, hero_hand: str) -> tuple[str, int]:
-    """Return the highest frequency action from solver output."""
-def parse_solver_output(output: str, hero_hand: str) -> tuple[str, int]:
-    """Return the highest frequency action from solver output.
-
-    Parameters
-    ----------
-    output : str
-        Raw text output from ``console_solver.exe`` which is expected to be JSON.
-    hero_hand : str
-        Hole cards of the hero concatenated without separators, e.g. ``"AhKh"``.
-
-    Returns
-    -------
-    tuple[str, int]
-        A pair of action name and bet size. Check/call/fold return ``0`` for the
-        size.
-    """
 
     try:
         data = json.loads(output)


### PR DESCRIPTION
## Summary
- remove duplicate helper implementations in `texas_solver.py`
- keep a single set of utilities and ensure `from __future__ import annotations` is at top

## Testing
- `ruff check texas_solver.py`
- `python -m unittest -v test_engine.py test_hand_strength_simple.py test_optimal_ai.py test_solver_ai.py test_texas_solver.py`