### PR TITLE
Pass game state to solver GUI

### DIFF
--- a/analysis_window.py
+++ b/analysis_window.py
@@ -14,7 +14,7 @@ from PyQt5.QtWidgets import (
 )
 
 from ai import estimate_equity_vs_random, optimal_ai_move
-from texas_solver import simple_parameter_file, launch_solver_gui
+from texas_solver import engine_parameter_file, launch_solver_gui
 from engine import PokerEngine
 
 
@@ -47,7 +47,7 @@ class AnalysisWindow(QMainWindow):
         layout.addWidget(self.solver_label, alignment=Qt.AlignCenter)
 
         self.launch_btn = QPushButton("Launch Solver GUI")
-        self.launch_btn.clicked.connect(launch_solver_gui)
+        self.launch_btn.clicked.connect(self._launch_solver_gui)
         layout.addWidget(self.launch_btn, alignment=Qt.AlignCenter)
 
     def set_context(self, engine: PokerEngine, seat: int) -> None:
@@ -99,6 +99,15 @@ class AnalysisWindow(QMainWindow):
         param_dir = os.path.join(os.path.dirname(__file__), "solver_params")
         os.makedirs(param_dir, exist_ok=True)
         path = os.path.join(param_dir, "current.json")
-        simple_parameter_file(self.engine, self.seat, path)
+        engine_parameter_file(self.engine, self.seat, path)
         self.solver_label.setText(f"Solver file: {path}")
 
+    def _launch_solver_gui(self) -> None:
+        """Launch the solver GUI with the current game state."""
+
+        param_dir = os.path.join(os.path.dirname(__file__), "solver_params")
+        os.makedirs(param_dir, exist_ok=True)
+        path = os.path.join(param_dir, "launch.json")
+        engine_parameter_file(self.engine, self.seat, path)
+        self.solver_label.setText(f"Solver file: {path}")
+        launch_solver_gui(param_file=path)

--- a/test_texas_solver.py
+++ b/test_texas_solver.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from pathlib import Path
 from engine import PokerEngine
@@ -29,7 +30,12 @@ class TestTexasSolverUtils(unittest.TestCase):
             self.assertTrue(text[-1].startswith("build_tree"))
 
     def test_engine_parameter_file(self):
-        eng = PokerEngine(num_players=2, starting_stack=100, sb_amt=1, bb_amt=2)
+        eng = PokerEngine(
+            num_players=2,
+            starting_stack=100,
+            sb_amt=1,
+            bb_amt=2,
+        )
         eng.new_hand()
         with tempfile.TemporaryDirectory() as tmpdir:
             out = os.path.join(tmpdir, "params.json")
@@ -39,6 +45,20 @@ class TestTexasSolverUtils(unittest.TestCase):
             self.assertEqual(data["hero_seat"], eng.turn)
             self.assertIn("0", data["holes"])
             self.assertEqual(data["pot"], eng.pot)
+
+    def test_launch_solver_gui_passes_param(self):
+        with patch("texas_solver.subprocess.Popen") as popen, patch(
+            "texas_solver.sys.platform",
+            "win32",
+        ):
+            texas_solver.launch_solver_gui(
+                exe_dir="C:/solver",
+                param_file="spot.json",
+            )
+            popen.assert_called_once_with([
+                "C:/solver/TexasSolverGui.exe",
+                "spot.json",
+            ])
 
 
 if __name__ == "__main__":

--- a/texas_solver.py
+++ b/texas_solver.py
@@ -41,12 +41,28 @@ def run_console_solver(
 
 
 def launch_solver_gui(
-    *, exe_dir: Path | str = DEFAULT_EXE_DIR, use_wine: bool | None = None
+    *,
+    exe_dir: Path | str = DEFAULT_EXE_DIR,
+    use_wine: bool | None = None,
+    param_file: Path | str | None = None,
 ) -> subprocess.Popen:
-    """Launch ``TexasSolverGui.exe`` and return the process handle."""
+    """Launch ``TexasSolverGui.exe`` and return the process handle.
+
+    Parameters
+    ----------
+    exe_dir : Path or str, optional
+        Directory containing the solver binary.
+    use_wine : bool or None, optional
+        Whether to prefix the command with ``wine`` on non-Windows systems.
+    param_file : Path or str, optional
+        Parameter file describing the current game state. If provided, it will
+        be passed as a command-line argument to the solver GUI.
+    """
 
     exe_path = Path(exe_dir) / "TexasSolverGui.exe"
     cmd = [str(exe_path)]
+    if param_file is not None:
+        cmd.append(str(param_file))
     if use_wine is None:
         use_wine = sys.platform != "win32"
     if use_wine:
@@ -82,7 +98,11 @@ def simple_parameter_file(
 
 
 def engine_parameter_file(engine: "PokerEngine", seat: int, path: str) -> str:
-    """Write a JSON parameter file for ``console_solver.exe`` from ``engine``."""
+    """Write a JSON parameter file for ``console_solver.exe``.
+
+    The file describes the given ``engine`` state from the perspective of the
+    player in ``seat``.
+    """
 
     data = {
         "hero_seat": seat,


### PR DESCRIPTION
## Summary
- extend `launch_solver_gui` to accept a parameter file
- update `AnalysisWindow` to pass the current game state when launching the solver
- generate solver files from the game engine state
- add tests for solver GUI launching

## Testing
- `flake8 analysis_window.py texas_solver.py test_texas_solver.py`
- `python -m unittest test_texas_solver.py -v`
- `python -m unittest -v`